### PR TITLE
Configure swagger-docs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+### Swagger Version
+swaggerVersion=2.2.0

--- a/raisedragon-api/build.gradle.kts
+++ b/raisedragon-api/build.gradle.kts
@@ -1,9 +1,14 @@
+val swaggerVersion: String by project.extra
+
 dependencies {
     api(project(":raisedragon-core"))
     api("org.springframework.boot:spring-boot-starter-data-jpa:3.0.4")
 
     implementation("org.springframework.boot:spring-boot-starter-validation:3.0.4")
     implementation("org.springframework.boot:spring-boot-starter-aop:3.0.4")
+    
+    // Swagger
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:$swaggerVersion")
 }
 
 application {

--- a/raisedragon-api/src/main/resources/application.yml
+++ b/raisedragon-api/src/main/resources/application.yml
@@ -3,3 +3,12 @@ spring:
     name: raisedragon
   messages:
     encoding: UTF-8
+
+# Swagger docs
+springdoc:
+  swagger-ui:
+    path: /api-docs
+    operations-sorter: alpha
+  api-docs:
+    groups:
+      enabled: true


### PR DESCRIPTION
Swagger Docs 설정했습니다

spring-fox의 경우 2020 이후로 업데이트 된 바 없고 Spring boot3 도 지원하지 않고 있습니다. (https://github.com/springfox/springfox)

spring-doc 2버전 중 가장 최신인 2.2.0 dependency 추가 후 설정 완료했습니다

#1 이 머지되고 머지되어야 합니다