### PR TITLE
전체 모듈에 사용될 전역 Exception, API 모듈의 ApiExceptionHandler를 추가합니다.

### DIFF
--- a/raisedragon-api/src/main/kotlin/com/whatever/raisedragon/common/ApiExceptionHandler.kt
+++ b/raisedragon-api/src/main/kotlin/com/whatever/raisedragon/common/ApiExceptionHandler.kt
@@ -1,0 +1,75 @@
+package com.whatever.raisedragon.common
+
+import com.whatever.raisedragon.common.exception.BaseException
+import com.whatever.raisedragon.common.exception.ExceptionCode.*
+import jakarta.validation.ConstraintViolationException
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.HttpRequestMethodNotSupportedException
+import org.springframework.web.bind.MissingServletRequestParameterException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+import kotlin.Exception
+
+@RestControllerAdvice
+class ApiExceptionHandler {
+
+    @ExceptionHandler(ConstraintViolationException::class)
+    private fun handlerConstraintViolationException(
+        exception: ConstraintViolationException,
+    ): Response<Any> {
+        return Response.of(
+            exceptionCode = E400_BAD_REQUEST,
+            detailMessage = DETAIL_MESSAGE_BY_PARAMETER_EXCEPTION
+        )
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException::class)
+    private fun handleMethodArgumentTypeMismatchException(
+        exception: MethodArgumentTypeMismatchException,
+    ): Response<Any> {
+        return Response.of(
+            exceptionCode = E400_BAD_REQUEST,
+            detailMessage = DETAIL_MESSAGE_BY_PARAMETER_EXCEPTION
+        )
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException::class)
+    private fun handleMissingServletRequestParameterException(
+        exception: MissingServletRequestParameterException,
+    ): Response<Any> {
+        return Response.of(
+            exceptionCode = E400_BAD_REQUEST,
+            detailMessage = DETAIL_MESSAGE_BY_PARAMETER_EXCEPTION
+        )
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException::class)
+    private fun httpRequestMethodNotSupportedException(
+        exception: HttpRequestMethodNotSupportedException
+    ): Response<Any> {
+        return Response.of(
+            exceptionCode = E405_METHOD_NOT_ALLOWED,
+            detailMessage = DETAIL_MESSAGE_BY_PARAMETER_EXCEPTION
+        )
+    }
+
+    @ExceptionHandler(BaseException::class)
+    private fun handleBaseException(exception: BaseException): ResponseEntity<Response<Any>> {
+        return ResponseEntity
+            .status(exception.exceptionCode.httpStatus)
+            .body(exception.toExceptionResponse())
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(Exception::class)
+    private fun handleInternalServerException(exception: Exception): Response<Any> {
+        return Response.of(E500_INTERNAL_SERVER_ERROR)
+    }
+
+    companion object {
+        const val DETAIL_MESSAGE_BY_PARAMETER_EXCEPTION = "Please Check Your Request Parameter"
+    }
+}

--- a/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/common/Response.kt
+++ b/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/common/Response.kt
@@ -1,0 +1,38 @@
+package com.whatever.raisedragon.common
+
+import com.whatever.raisedragon.common.exception.BaseException
+import com.whatever.raisedragon.common.exception.ExceptionCode
+
+
+data class Response<T>(
+    val status: Int,
+    val data: T?,
+    val exception: Exception?
+) {
+    companion object {
+        fun of(exceptionCode: ExceptionCode, data: Any? = null, detailMessage: String? = null): Response<Any> {
+            return Response(
+                status = exceptionCode.httpStatus.value(),
+                data = data,
+                exception = Exception(
+                    code = exceptionCode.exceptionCode,
+                    detailMessage = detailMessage
+                )
+            )
+        }
+    }
+}
+
+data class Exception(
+    val code: String,
+    val detailMessage: String?
+)
+
+fun throwException(
+    exception: ExceptionCode,
+): Nothing {
+    throw BaseException.from(
+        exceptionCode = exception,
+        executionMessage = exception.exceptionMessage
+    )
+}

--- a/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/common/exception/BaseException.kt
+++ b/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/common/exception/BaseException.kt
@@ -1,0 +1,35 @@
+package com.whatever.raisedragon.common.exception
+
+class BaseException(
+    val exceptionCode: ExceptionCode,
+    val exceptionMessage: String,
+    override val cause: Throwable?,
+) : RuntimeException(
+    exceptionCode.toString(),
+    cause
+) {
+
+    fun toExceptionResponse(): ExceptionResponse {
+        return ExceptionResponse(
+            status = exceptionCode.httpStatus.value(),
+            exception = Exception(
+                code = exceptionCode.exceptionCode,
+                detailMessage = exceptionCode.exceptionMessage
+            )
+        )
+    }
+
+    companion object {
+        fun from(
+            exceptionCode: ExceptionCode,
+            executionMessage: String,
+            cause: Throwable? = null
+        ): BaseException {
+            return BaseException(
+                exceptionCode = exceptionCode,
+                exceptionMessage = executionMessage,
+                cause = cause
+            )
+        }
+    }
+}

--- a/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/common/exception/ExceptionCode.kt
+++ b/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/common/exception/ExceptionCode.kt
@@ -1,0 +1,33 @@
+package com.whatever.raisedragon.common.exception
+
+import org.springframework.http.HttpStatus
+
+enum class ExceptionCode(
+    val httpStatus: HttpStatus,
+    val exceptionCode: String,
+    val exceptionMessage: String,
+) {
+
+    E400_BAD_REQUEST(HttpStatus.BAD_REQUEST, "000", "필수 파라미터 값이 없거나 잘못된 값으로 요청을 보낸 경우 발생"),
+
+    // ------------------------------ 401 ------------------------------
+    E401_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "000", "유효하지 않은 인증 토큰을 사용한 경우 발생"),
+
+    // ------------------------------ 403 ------------------------------
+    E403_FORBIDDEN(HttpStatus.FORBIDDEN, "000", "사용 권한이 없는 경우 발생"),
+
+    // ------------------------------ 404 ------------------------------
+    E404_NOT_FOUND(HttpStatus.NOT_FOUND, "000", "요청한 리소스가 존재하지 않는 경우 발생"),
+
+    // ------------------------------ 405 ------------------------------
+    E405_METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "000", "HTTP Method가 잘못된 경우"),
+
+    // ------------------------------ 409 ------------------------------
+    E409_CONFLICT(HttpStatus.CONFLICT, "000", "요청한 리소스가 중복된 경우 발생"),
+
+    // ------------------------------ 500 ------------------------------
+    E500_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "000", "서버 내부에 문제 발생"),
+
+    // ------------------------------ 501 ------------------------------
+    E501_NOT_IMPLEMENTED(HttpStatus.NOT_IMPLEMENTED, "000", "지원하지 않는 타입의 요청"),
+}


### PR DESCRIPTION
전체 모듈에 사용될 전역 Exception, API 모듈의 ApiExceptionHandler를 추가합니다.

비즈니스 로직 간 예외를 던질 때

```kotlin
fun throwException(
    exception: ExceptionCode,
): Nothing {
    throw BaseException.from(
        exceptionCode = exception,
        executionMessage = exception.exceptionMessage
    )
}
```

위 메서드를 활용할 수 있습니다.

예시)

```kotlin

return userRepository.findByNickname(nickname)) ?: throwException(ExceptionCode.E404_NOT_FOUNDED)
```

---

비즈니스 로직에서 던져진 예외는 API모듈의 ExceptionHandler가 캐치합니다.

```kotlin
@ExceptionHandler(BaseException::class)
private fun handleBaseException(exception: BaseException): ResponseEntity<ExceptionResponse> {
        return ResponseEntity
            .status(exception.exceptionCode.httpStatus)
            .body(exception.toExceptionResponse())
}
```