### PR TITLE
다짐 생성 API를 추가합니다.

### DIFF
--- a/raisedragon-api/src/main/kotlin/com/whatever/raisedragon/applicationservice/GoalApplicationService.kt
+++ b/raisedragon-api/src/main/kotlin/com/whatever/raisedragon/applicationservice/GoalApplicationService.kt
@@ -1,0 +1,56 @@
+package com.whatever.raisedragon.applicationservice
+
+import com.whatever.raisedragon.domain.gifticon.GifticonService
+import com.whatever.raisedragon.domain.goal.*
+import com.whatever.raisedragon.domain.goalgifticon.GoalGifticonService
+import com.whatever.raisedragon.domain.user.User
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Transactional
+@Service
+class GoalApplicationService(
+    private val goalService: GoalService,
+    private val gifticonService: GifticonService,
+    private val goalGifticonService: GoalGifticonService
+) {
+
+    fun createGoal(
+        content: Content,
+        bettingType: BettingType,
+        threshold: Threshold,
+        startDate: LocalDateTime,
+        endDate: LocalDateTime,
+        user: User,
+        presignedURL: String
+    ): Goal {
+        if (bettingType == BettingType.BILLING) {
+            val goal = goalService.create(
+                content = content,
+                bettingType = bettingType,
+                threshold = threshold,
+                startDate = startDate,
+                endDate = endDate
+            )
+            val gifticon = gifticonService.create(
+                user = user,
+                presignedURL = presignedURL
+            )
+            goalGifticonService.create(
+                goal = goal,
+                gifticon = gifticon,
+                user = user
+            )
+            return goal
+        }
+
+        return goalService.create(
+            content = content,
+            bettingType = bettingType,
+            threshold = threshold,
+            startDate = startDate,
+            endDate = endDate
+        )
+    }
+}

--- a/raisedragon-api/src/main/kotlin/com/whatever/raisedragon/controller/goal/GoalController.kt
+++ b/raisedragon-api/src/main/kotlin/com/whatever/raisedragon/controller/goal/GoalController.kt
@@ -1,6 +1,10 @@
 package com.whatever.raisedragon.controller.goal
 
+import com.whatever.raisedragon.applicationservice.GoalApplicationService
 import com.whatever.raisedragon.common.Response
+import com.whatever.raisedragon.domain.goal.Content
+import com.whatever.raisedragon.domain.goal.Threshold
+import com.whatever.raisedragon.domain.user.User
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
@@ -10,15 +14,30 @@ import org.springframework.web.bind.annotation.*
 @Tag(name = "Goal", description = "Goal API")
 @RestController
 @RequestMapping("/v1/goal")
-class GoalController {
+class GoalController(
+    private val goalApplicationService: GoalApplicationService
+) {
 
     @ResponseStatus(HttpStatus.CREATED)
-    @Operation(summary = "Creating Goal API", description = "Create Goal")
+    @Operation(summary = "Creating Goal API", description = "다짐을 생성합니다.")
     @PostMapping
     fun create(
-        @Valid @RequestBody request: GoalCreateRequest
+        @Valid @RequestBody request: GoalCreateRequest,
+        user: User
     ): Response<GoalResponse> {
-        return Response.success(GoalResponse.sample())
+        return Response.success(
+            GoalResponse.of(
+                goalApplicationService.createGoal(
+                    bettingType = request.type,
+                    content = Content(request.content),
+                    presignedURL = request.presig,
+                    threshold = Threshold(request.threshold),
+                    startDate = request.startDate,
+                    endDate = request.endDate,
+                    user = user
+                )
+            )
+        )
     }
 
     @Operation(summary = "Deleting Goal API", description = "Delete Goal")

--- a/raisedragon-api/src/main/kotlin/com/whatever/raisedragon/controller/goal/GoalDto.kt
+++ b/raisedragon-api/src/main/kotlin/com/whatever/raisedragon/controller/goal/GoalDto.kt
@@ -1,9 +1,13 @@
 package com.whatever.raisedragon.controller.goal
 
 import com.whatever.raisedragon.domain.goal.BettingType
+import com.whatever.raisedragon.domain.goal.Content
+import com.whatever.raisedragon.domain.goal.Goal
+import com.whatever.raisedragon.domain.goal.Threshold
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.PositiveOrZero
+import org.springframework.web.multipart.MultipartFile
 import java.time.LocalDateTime
 
 @Schema(description = "[Request] 다짐 생성")
@@ -15,6 +19,9 @@ data class GoalCreateRequest(
     @Schema(description = "다짐 내용")
     @field:NotNull
     val content: String,
+
+    @Schema(description = "다짐 기프티콘의 Presigned URL")
+    val presig: String,
 
     @Schema(description = "다짐 인증 횟수")
     @field:NotNull
@@ -39,10 +46,10 @@ data class GoalResponse(
     val type: BettingType,
 
     @Schema(description = "다짐 내용")
-    val content: String,
+    val content: Content,
 
     @Schema(description = "다짐 인증 횟수")
-    val threshold: Int,
+    val threshold: Threshold,
 
     @Schema(description = "다짐 시작 시간")
     val startDate: LocalDateTime,
@@ -51,11 +58,11 @@ data class GoalResponse(
     val endDate: LocalDateTime
 ) {
     companion object {
-        fun sample(): GoalResponse = GoalResponse(
-            id = 1L,
-            type = BettingType.BILLING,
-            content = "Sample Goal's content",
-            threshold = 4,
+        fun of(goal: Goal): GoalResponse = GoalResponse(
+            id = goal.id,
+            type = goal.type,
+            content = goal.content,
+            threshold = goal.threshold,
             startDate = LocalDateTime.now().plusDays(1L),
             endDate = LocalDateTime.now().plusMonths(1L)
         )

--- a/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/gifticon/GifticonEntity.kt
+++ b/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/gifticon/GifticonEntity.kt
@@ -21,6 +21,15 @@ class GifticonEntity(
 
 ) : BaseEntity()
 
+fun Gifticon.fromDto(userEntity: UserEntity): GifticonEntity = GifticonEntity(
+    userEntity = userEntity,
+    url = url,
+    isValidated = isValidated,
+)
+
 @Embeddable
-data class URL(val url: String)
+data class URL(
+    @Column(name = "url")
+    val value: String
+)
 

--- a/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/gifticon/GifticonService.kt
+++ b/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/gifticon/GifticonService.kt
@@ -1,0 +1,26 @@
+package com.whatever.raisedragon.domain.gifticon
+
+import com.whatever.raisedragon.domain.user.User
+import com.whatever.raisedragon.domain.user.fromDto
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+@Service
+class GifticonService(
+    private val gifticonRepository: GifticonRepository,
+) {
+
+    fun create(
+        user: User,
+        presignedURL: String,
+    ): Gifticon {
+        val gifticon = gifticonRepository.save(
+            GifticonEntity(
+                userEntity = user.fromDto(),
+                url = URL(presignedURL)
+            )
+        )
+        return gifticon.toDto()
+    }
+}

--- a/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goal/GoalEntity.kt
+++ b/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goal/GoalEntity.kt
@@ -30,16 +30,31 @@ class GoalEntity(
 
 ) : BaseEntity()
 
+fun Goal.fromDto(): GoalEntity = GoalEntity(
+    type = type,
+    content = content,
+    threshold = threshold,
+    result = result,
+    startDate = startDate,
+    endDate = endDate,
+)
+
 enum class BettingType {
     FREE, BILLING
 }
 
 @Embeddable
-data class Content(val content: String)
+data class Content(
+    @Column(name = "content")
+    val value: String
+)
 
 enum class Result {
     PROCEEDING, SUCCESS, FAIL
 }
 
 @Embeddable
-data class Threshold(val threshold: Int)
+data class Threshold(
+    @Column(name = "threshold")
+    val value: Int
+)

--- a/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goal/GoalService.kt
+++ b/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goal/GoalService.kt
@@ -1,0 +1,32 @@
+package com.whatever.raisedragon.domain.goal
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Transactional
+@Service
+class GoalService(
+    private val goalRepository: GoalRepository
+) {
+
+    fun create(
+        content: Content,
+        bettingType: BettingType,
+        threshold: Threshold,
+        startDate: LocalDateTime,
+        endDate: LocalDateTime,
+    ): Goal {
+        val goal = goalRepository.save(
+            GoalEntity(
+                type = bettingType,
+                content = content,
+                threshold = threshold,
+                result = Result.PROCEEDING,
+                startDate = startDate,
+                endDate = endDate
+            )
+        )
+        return goal.toDto()
+    }
+}

--- a/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goalgifticon/GoalGifticonService.kt
+++ b/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goalgifticon/GoalGifticonService.kt
@@ -1,0 +1,30 @@
+package com.whatever.raisedragon.domain.goalgifticon
+
+import com.whatever.raisedragon.domain.gifticon.Gifticon
+import com.whatever.raisedragon.domain.gifticon.fromDto
+import com.whatever.raisedragon.domain.goal.Goal
+import com.whatever.raisedragon.domain.goal.fromDto
+import com.whatever.raisedragon.domain.user.User
+import com.whatever.raisedragon.domain.user.fromDto
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+@Service
+class GoalGifticonService(
+    private val goalGifticonRepository: GoalGifticonRepository
+) {
+
+    fun create(
+        goal: Goal,
+        gifticon: Gifticon,
+        user: User,
+    ) {
+        goalGifticonRepository.save(
+            GoalGifticonEntity(
+                goal.fromDto(),
+                gifticon.fromDto(user.fromDto())
+            )
+        )
+    }
+}


### PR DESCRIPTION
다짐 생성 API를 추가합니다.

`PresignedURL`방식으로 구현했습니다. 추후, 클라이언트의 공수판단에 따라서 S3Agent를 구현한 구현체를 사용하여 직접 업로드 로직으로 변경할 수 있습니다.