### PR TITLE
GoalProof 도메인을 리팩터링합니다.

### DIFF
--- a/raisedragon-api/src/main/kotlin/com/whatever/raisedragon/applicationservice/GoalProofApplicationService.kt
+++ b/raisedragon-api/src/main/kotlin/com/whatever/raisedragon/applicationservice/GoalProofApplicationService.kt
@@ -2,11 +2,11 @@ package com.whatever.raisedragon.applicationservice
 
 import com.whatever.raisedragon.controller.goalproof.GoalProofCreateUpdateResponse
 import com.whatever.raisedragon.controller.goalproof.GoalProofRetrieveResponse
+import com.whatever.raisedragon.domain.gifticon.URL
 import com.whatever.raisedragon.domain.goal.GoalService
-import com.whatever.raisedragon.domain.goalproof.Document
+import com.whatever.raisedragon.domain.goalproof.Comment
 import com.whatever.raisedragon.domain.goalproof.GoalProofService
 import com.whatever.raisedragon.domain.user.UserService
-import com.whatever.raisedragon.security.authentication.UserInfo
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -21,19 +21,22 @@ class GoalProofApplicationService(
     fun create(
         userId: Long,
         goalId: Long,
-        document: Document
+        url: String,
+        comment: String
     ): GoalProofCreateUpdateResponse {
         val goalProof = goalProofService.create(
             user = userService.loadById(userId),
             goal = goalService.loadById(goalId),
-            document = document
+            url = URL(url),
+            comment = Comment(comment)
         )
         return GoalProofCreateUpdateResponse(
             GoalProofRetrieveResponse(
                 id = goalProof.id,
                 userId = goalProof.userId,
                 goalId = goalProof.goalId,
-                document = document
+                url = goalProof.url,
+                comment = goalProof.comment
             )
         )
     }
@@ -43,7 +46,8 @@ class GoalProofApplicationService(
             id = 0L,
             userId = 0L,
             goalId = 0L,
-            document = Document("Fake Document")
+            url = URL("goalProof.url"),
+            comment = Comment("goalProof.comment")
         )
     }
 }

--- a/raisedragon-api/src/main/kotlin/com/whatever/raisedragon/controller/betting/BettingController.kt
+++ b/raisedragon-api/src/main/kotlin/com/whatever/raisedragon/controller/betting/BettingController.kt
@@ -41,13 +41,13 @@ class BettingController(
         return Response.success(bettingApplicationService.retrieve())
     }
 
-    @Operation(summary = "Betting update API", description = "Update Betting")
-    @PutMapping
-    fun update(
-        @RequestBody bettingUpdateRequest: BettingUpdateRequest
-    ): Response<BettingCreateUpdateResponse> {
-        return Response.success(bettingApplicationService.create())
-    }
+//    @Operation(summary = "Betting update API", description = "Update Betting")
+//    @PutMapping
+//    fun update(
+//        @RequestBody bettingUpdateRequest: BettingUpdateRequest
+//    ): Response<BettingCreateUpdateResponse> {
+//        return Response.success(bettingApplicationService.create())
+//    }
 
     @Operation(summary = "Betting delete API", description = "Delete Betting")
     @DeleteMapping("{bettingId}")

--- a/raisedragon-api/src/main/kotlin/com/whatever/raisedragon/controller/goal/GoalController.kt
+++ b/raisedragon-api/src/main/kotlin/com/whatever/raisedragon/controller/goal/GoalController.kt
@@ -35,7 +35,7 @@ class GoalController(
                     threshold = Threshold(request.threshold),
                     startDate = request.startDate,
                     endDate = request.endDate,
-                    userId = userInfo.id
+                    userId = userinfo.id
                 )
             )
         )

--- a/raisedragon-api/src/main/kotlin/com/whatever/raisedragon/controller/goalproof/GoalProofController.kt
+++ b/raisedragon-api/src/main/kotlin/com/whatever/raisedragon/controller/goalproof/GoalProofController.kt
@@ -2,7 +2,6 @@ package com.whatever.raisedragon.controller.goalproof
 
 import com.whatever.raisedragon.applicationservice.GoalProofApplicationService
 import com.whatever.raisedragon.common.Response
-import com.whatever.raisedragon.domain.goalproof.Document
 import com.whatever.raisedragon.security.authentication.UserInfo
 import com.whatever.raisedragon.security.resolver.GetAuth
 import io.swagger.v3.oas.annotations.Operation
@@ -29,7 +28,8 @@ class GoalProofController(
             goalProofApplicationService.create(
                 userId = userInfo.id,
                 goalId = goalProofCreateRequest.goalId,
-                document = Document(goalProofCreateRequest.document)
+                url = goalProofCreateRequest.url,
+                comment = goalProofCreateRequest.comment,
             )
         )
     }

--- a/raisedragon-api/src/main/kotlin/com/whatever/raisedragon/controller/goalproof/GoalProofDto.kt
+++ b/raisedragon-api/src/main/kotlin/com/whatever/raisedragon/controller/goalproof/GoalProofDto.kt
@@ -1,6 +1,7 @@
 package com.whatever.raisedragon.controller.goalproof
 
-import com.whatever.raisedragon.domain.goalproof.Document
+import com.whatever.raisedragon.domain.gifticon.URL
+import com.whatever.raisedragon.domain.goalproof.Comment
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "[Request] 인증내역 생성")
@@ -9,7 +10,10 @@ data class GoalProofCreateRequest(
     val goalId: Long,
 
     @Schema(description = "다짐 인증에 대한 PresignedURL")
-    val document: String
+    val url: String,
+
+    @Schema(description = "다짐 인증에 대한 부연설명")
+    val comment: String
 )
 
 @Schema(description = "[Request] 인증내역 수정")
@@ -36,6 +40,9 @@ data class GoalProofRetrieveResponse(
     @Schema(description = "GoalId")
     val goalId: Long,
 
-    @Schema(description = "인증 상세")
-    val document: Document
+    @Schema(description = "인증 사진")
+    val url: URL,
+
+    @Schema(description = "인증 부연설명")
+    val comment: Comment,
 )

--- a/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goalproof/GoalProof.kt
+++ b/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goalproof/GoalProof.kt
@@ -1,14 +1,14 @@
 package com.whatever.raisedragon.domain.goalproof
 
-import com.whatever.raisedragon.domain.goal.Goal
-import com.whatever.raisedragon.domain.user.User
+import com.whatever.raisedragon.domain.gifticon.URL
 import java.time.LocalDateTime
 
 data class GoalProof(
     val id: Long,
     val userId: Long,
     val goalId: Long,
-    val document: Document,
+    val url: URL,
+    val comment: Comment,
     var deletedAt: LocalDateTime?,
     var createdAt: LocalDateTime?,
     var updatedAt: LocalDateTime?
@@ -18,7 +18,8 @@ fun GoalProofEntity.toDto(): GoalProof = GoalProof(
     id = id,
     userId = userEntity.id,
     goalId = goalEntity.id,
-    document = document,
+    url = url,
+    comment = comment,
     deletedAt = deletedAt,
     createdAt = createdAt,
     updatedAt = updatedAt

--- a/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goalproof/GoalProofEntity.kt
+++ b/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goalproof/GoalProofEntity.kt
@@ -1,6 +1,7 @@
 package com.whatever.raisedragon.domain.goalproof
 
 import com.whatever.raisedragon.domain.BaseEntity
+import com.whatever.raisedragon.domain.gifticon.URL
 import com.whatever.raisedragon.domain.goal.GoalEntity
 import com.whatever.raisedragon.domain.user.UserEntity
 import jakarta.persistence.*
@@ -17,13 +18,16 @@ class GoalProofEntity(
     @JoinColumn(name = "goal_id")
     val goalEntity: GoalEntity,
 
-    @Embedded
-    val document: Document
+    @Column(name = "url")
+    val url: URL,
+
+    @Column(name = "comment")
+    val comment: Comment
 
 ) : BaseEntity()
 
 @Embeddable
-data class Document(
-    @Column(name = "document")
-    val value: String
+data class Comment(
+    @Column(name = "comment")
+    val value: String,
 )

--- a/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goalproof/GoalProofService.kt
+++ b/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goalproof/GoalProofService.kt
@@ -1,5 +1,6 @@
 package com.whatever.raisedragon.domain.goalproof
 
+import com.whatever.raisedragon.domain.gifticon.URL
 import com.whatever.raisedragon.domain.goal.Goal
 import com.whatever.raisedragon.domain.goal.fromDto
 import com.whatever.raisedragon.domain.user.User
@@ -16,13 +17,15 @@ class GoalProofService(
     fun create(
         user: User,
         goal: Goal,
-        document: Document
+        url: URL,
+        comment: Comment
     ): GoalProof {
         val goalProof = goalProofRepository.save(
             GoalProofEntity(
                 userEntity = user.fromDto(),
                 goalEntity = goal.fromDto(),
-                document = document
+                url = url,
+                comment = comment,
             )
         )
         return goalProof.toDto()

--- a/raisedragon-core/src/main/resources/ddl/V1_DDL.sql
+++ b/raisedragon-core/src/main/resources/ddl/V1_DDL.sql
@@ -82,6 +82,8 @@ create table if not exists goal_proof
     goal_id    bigint       not null,
     user_id    bigint       not null,
     document   varchar(255) not null,
+    url        varchar(255) not null,
+    comment    varchar(255) not null,
     deleted_at datetime(6)  null,
     created_at datetime(6)  not null,
     updated_at datetime(6)  not null


### PR DESCRIPTION
기존 GoalProof의 Column에는 `document`라고 지정된 컬럼만 존재했습니다.

하지만 아래 디자인인에는 인증 사진과 첨언을 기록할 수 있도록 되어있어 컬럼을 추가합니다.

<img width="407" alt="image" src="https://github.com/whatever-mentoring/GoalBetting-Server/assets/60564431/5eca4d73-1f11-49e7-9889-6a07cf845d00">
