### PR TITLE
다짐 생성 API에 다짐 갯수에 대한 검증 로직을 추가합니다. + GoalEntity Column 변경사항을 반영합니다.

### DIFF
--- a/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/gifticon/GifticonService.kt
+++ b/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/gifticon/GifticonService.kt
@@ -1,7 +1,6 @@
 package com.whatever.raisedragon.domain.gifticon
 
-import com.whatever.raisedragon.domain.user.User
-import com.whatever.raisedragon.domain.user.fromDto
+import com.whatever.raisedragon.domain.user.UserRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -9,15 +8,16 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class GifticonService(
     private val gifticonRepository: GifticonRepository,
+    private val userRepository: UserRepository
 ) {
 
     fun create(
-        user: User,
+        userId: Long,
         presignedURL: String,
     ): Gifticon {
         val gifticon = gifticonRepository.save(
             GifticonEntity(
-                userEntity = user.fromDto(),
+                userEntity = userRepository.findById(userId).get(),
                 url = URL(presignedURL)
             )
         )

--- a/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goal/Goal.kt
+++ b/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goal/Goal.kt
@@ -4,6 +4,7 @@ import java.time.LocalDateTime
 
 data class Goal(
     val id: Long,
+    val userId: Long,
     val type: BettingType,
     val content: Content,
     val threshold: Threshold,
@@ -17,6 +18,7 @@ data class Goal(
 
 fun GoalEntity.toDto(): Goal = Goal(
     id = id,
+    userId = userEntity.id,
     type = type,
     content = content,
     threshold = threshold,

--- a/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goal/GoalEntity.kt
+++ b/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goal/GoalEntity.kt
@@ -1,12 +1,17 @@
 package com.whatever.raisedragon.domain.goal
 
 import com.whatever.raisedragon.domain.BaseEntity
+import com.whatever.raisedragon.domain.user.UserEntity
 import jakarta.persistence.*
 import java.time.LocalDateTime
 
 @Table(name = "goal")
 @Entity
 class GoalEntity(
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    val userEntity: UserEntity,
 
     @Enumerated(EnumType.STRING)
     val type: BettingType,
@@ -30,7 +35,8 @@ class GoalEntity(
 
 ) : BaseEntity()
 
-fun Goal.fromDto(): GoalEntity = GoalEntity(
+fun Goal.fromDto(userEntity: UserEntity): GoalEntity = GoalEntity(
+    userEntity = userEntity,
     type = type,
     content = content,
     threshold = threshold,

--- a/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goal/GoalRepository.kt
+++ b/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goal/GoalRepository.kt
@@ -1,7 +1,10 @@
 package com.whatever.raisedragon.domain.goal
 
+import com.whatever.raisedragon.domain.user.UserEntity
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface GoalRepository : JpaRepository<GoalEntity, Long>
+interface GoalRepository : JpaRepository<GoalEntity, Long> {
+    fun findAllByUserEntity(userEntity: UserEntity): List<GoalEntity>
+}

--- a/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goal/GoalService.kt
+++ b/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goal/GoalService.kt
@@ -1,5 +1,6 @@
 package com.whatever.raisedragon.domain.goal
 
+import com.whatever.raisedragon.domain.user.UserRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -8,10 +9,12 @@ import java.time.LocalDateTime
 @Transactional
 @Service
 class GoalService(
-    private val goalRepository: GoalRepository
+    private val goalRepository: GoalRepository,
+    private val userRepository: UserRepository
 ) {
 
     fun create(
+        userId: Long,
         content: Content,
         bettingType: BettingType,
         threshold: Threshold,
@@ -20,6 +23,7 @@ class GoalService(
     ): Goal {
         val goal = goalRepository.save(
             GoalEntity(
+                userEntity = userRepository.findById(userId).get(),
                 type = bettingType,
                 content = content,
                 threshold = threshold,
@@ -34,5 +38,12 @@ class GoalService(
     @Transactional(readOnly = true)
     fun loadById(id: Long): Goal {
         return goalRepository.findByIdOrNull(id)?.toDto() ?: throw Exception()
+    }
+
+    @Transactional(readOnly = true)
+    fun loadAllByUserId(userId: Long): List<GoalEntity> {
+        return goalRepository.findAllByUserEntity(
+            userRepository.findById(userId).get()
+        )
     }
 }

--- a/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goalgifticon/GoalGifticonService.kt
+++ b/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goalgifticon/GoalGifticonService.kt
@@ -1,29 +1,27 @@
 package com.whatever.raisedragon.domain.goalgifticon
 
-import com.whatever.raisedragon.domain.gifticon.Gifticon
-import com.whatever.raisedragon.domain.gifticon.fromDto
-import com.whatever.raisedragon.domain.goal.Goal
-import com.whatever.raisedragon.domain.goal.fromDto
-import com.whatever.raisedragon.domain.user.User
-import com.whatever.raisedragon.domain.user.fromDto
+import com.whatever.raisedragon.domain.gifticon.GifticonRepository
+import com.whatever.raisedragon.domain.goal.GoalRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Transactional
 @Service
 class GoalGifticonService(
-    private val goalGifticonRepository: GoalGifticonRepository
+    private val goalGifticonRepository: GoalGifticonRepository,
+    private val goalRepository: GoalRepository,
+    private val gifticonRepository: GifticonRepository
 ) {
 
     fun create(
-        goal: Goal,
-        gifticon: Gifticon,
-        user: User,
+        goalId: Long,
+        gifticonId: Long,
+        userId: Long,
     ) {
         goalGifticonRepository.save(
             GoalGifticonEntity(
-                goal.fromDto(),
-                gifticon.fromDto(user.fromDto())
+                goalEntity = goalRepository.findById(goalId).get(),
+                gifticon = gifticonRepository.findById(gifticonId).get()
             )
         )
     }

--- a/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goalproof/GoalProofService.kt
+++ b/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goalproof/GoalProofService.kt
@@ -23,7 +23,7 @@ class GoalProofService(
         val goalProof = goalProofRepository.save(
             GoalProofEntity(
                 userEntity = user.fromDto(),
-                goalEntity = goal.fromDto(),
+                goalEntity = goal.fromDto(user.fromDto()),
                 url = url,
                 comment = comment,
             )

--- a/raisedragon-core/src/main/resources/ddl/V1_DDL.sql
+++ b/raisedragon-core/src/main/resources/ddl/V1_DDL.sql
@@ -12,6 +12,7 @@ create table if not exists gifticon
 create table if not exists goal
 (
     id         bigint auto_increment primary key,
+    user_id    bigint                                 not null,
     content    varchar(255)                           not null,
     type       enum ('FREE', 'BILLING')               not null,
     threshold  int                                    not null,


### PR DESCRIPTION
다짐 생성 API에 이미 진행 중인 다짐이 있는 경우에 대한 검증 로직을 추가합니다.

또한, 기존 Goal에는 Goal을 생성한 유저에 대한 컬럼이 누락되어있어 이를 추가합니다.