### PR TITLE
Implement retrieving goal-proof API

### DIFF
--- a/raisedragon-api/src/main/kotlin/com/whatever/raisedragon/applicationservice/GoalProofApplicationService.kt
+++ b/raisedragon-api/src/main/kotlin/com/whatever/raisedragon/applicationservice/GoalProofApplicationService.kt
@@ -1,6 +1,9 @@
 package com.whatever.raisedragon.applicationservice
 
+import com.whatever.raisedragon.common.exception.BaseException
+import com.whatever.raisedragon.common.exception.ExceptionCode
 import com.whatever.raisedragon.controller.goalproof.GoalProofCreateUpdateResponse
+import com.whatever.raisedragon.controller.goalproof.GoalProofListRetrieveResponse
 import com.whatever.raisedragon.controller.goalproof.GoalProofRetrieveResponse
 import com.whatever.raisedragon.domain.gifticon.URL
 import com.whatever.raisedragon.domain.goal.GoalService
@@ -30,24 +33,16 @@ class GoalProofApplicationService(
             url = URL(url),
             comment = Comment(comment)
         )
-        return GoalProofCreateUpdateResponse(
-            GoalProofRetrieveResponse(
-                id = goalProof.id,
-                userId = goalProof.userId,
-                goalId = goalProof.goalId,
-                url = goalProof.url,
-                comment = goalProof.comment
-            )
-        )
+        return GoalProofCreateUpdateResponse(GoalProofRetrieveResponse.of(goalProof))
     }
 
-    fun retrieve(): GoalProofRetrieveResponse {
-        return GoalProofRetrieveResponse(
-            id = 0L,
-            userId = 0L,
-            goalId = 0L,
-            url = URL("goalProof.url"),
-            comment = Comment("goalProof.comment")
-        )
+    fun retrieve(goalProofId: Long): GoalProofRetrieveResponse {
+        val goalProof = goalProofService.findById(goalProofId) ?: throw BaseException.of(ExceptionCode.E404_NOT_FOUND)
+        return GoalProofRetrieveResponse.of(goalProof)
+    }
+
+    fun retrieveAll(goalId: Long, userId: Long): GoalProofListRetrieveResponse {
+        val goalProofs = goalProofService.findAllByGoalIdAndUserId(goalId, userId)
+        return GoalProofListRetrieveResponse(goalProofs.map { GoalProofRetrieveResponse.of(it) })
     }
 }

--- a/raisedragon-api/src/main/kotlin/com/whatever/raisedragon/controller/goalproof/GoalProofController.kt
+++ b/raisedragon-api/src/main/kotlin/com/whatever/raisedragon/controller/goalproof/GoalProofController.kt
@@ -34,11 +34,17 @@ class GoalProofController(
         )
     }
 
-    @Operation(summary = "GoalProof retrieve API", description = "Retrieve GoalProof")
+    @Operation(summary = "Retrieving single GoalProof API", description = "단건 다짐 인증을 조회합니다")
     @GetMapping("/{goalProofId}")
     fun retrieve(
         @PathVariable goalProofId: Long
     ): Response<GoalProofRetrieveResponse> {
-        return Response.success(goalProofApplicationService.retrieve())
+        return Response.success(goalProofApplicationService.retrieve(goalProofId))
+    }
+
+    @Operation(summary = "Retrieving single GoalProof API", description = "모든 다짐 인증을 조회합니다")
+    @GetMapping
+    fun retrieveAll(@GetAuth userInfo: UserInfo, @RequestBody request: GoalProofRetrieveAllRequest): Response<GoalProofListRetrieveResponse> {
+        return Response.success(goalProofApplicationService.retrieveAll(request.goalId, userInfo.id))
     }
 }

--- a/raisedragon-api/src/main/kotlin/com/whatever/raisedragon/controller/goalproof/GoalProofDto.kt
+++ b/raisedragon-api/src/main/kotlin/com/whatever/raisedragon/controller/goalproof/GoalProofDto.kt
@@ -1,7 +1,6 @@
 package com.whatever.raisedragon.controller.goalproof
 
-import com.whatever.raisedragon.domain.gifticon.URL
-import com.whatever.raisedragon.domain.goalproof.Comment
+import com.whatever.raisedragon.domain.goalproof.GoalProof
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "[Request] 인증내역 생성")
@@ -16,8 +15,8 @@ data class GoalProofCreateRequest(
     val comment: String
 )
 
-@Schema(description = "[Request] 인증내역 수정")
-data class GoalProofUpdateRequest(
+@Schema(description = "[Request] 모든 다짐 인증 조회")
+data class GoalProofRetrieveAllRequest(
     @Schema(description = "Goal Id")
     val goalId: Long,
 )
@@ -28,7 +27,7 @@ data class GoalProofCreateUpdateResponse(
     val goalProofRetrieveResponse: GoalProofRetrieveResponse
 )
 
-@Schema(description = "[Response] 인증내역 조회")
+@Schema(description = "[Response] 단건 다짐 인증 조회")
 data class GoalProofRetrieveResponse(
 
     @Schema(description = "GoalProofId")
@@ -41,8 +40,24 @@ data class GoalProofRetrieveResponse(
     val goalId: Long,
 
     @Schema(description = "인증 사진")
-    val url: URL,
+    val url: String,
 
     @Schema(description = "인증 부연설명")
-    val comment: Comment,
+    val comment: String,
+) {
+    companion object {
+        fun of(goalProof: GoalProof): GoalProofRetrieveResponse = GoalProofRetrieveResponse(
+            id = goalProof.id,
+            userId = goalProof.userId,
+            goalId = goalProof.goalId,
+            url = goalProof.url.value,
+            comment = goalProof.comment.value
+        )
+    }
+}
+
+@Schema(description = "[Response] 모든 다짐 인증 조회")
+data class GoalProofListRetrieveResponse(
+    @Schema(description = "모든 다짐 인증")
+    val goalProofs: List<GoalProofRetrieveResponse>
 )

--- a/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goalproof/GoalProofRepository.kt
+++ b/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goalproof/GoalProofRepository.kt
@@ -1,7 +1,11 @@
 package com.whatever.raisedragon.domain.goalproof
 
+import com.whatever.raisedragon.domain.goal.GoalEntity
+import com.whatever.raisedragon.domain.user.UserEntity
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface GoalProofRepository : JpaRepository<GoalProofEntity, Long>
+interface GoalProofRepository : JpaRepository<GoalProofEntity, Long> {
+    fun findAllByUserEntityAndGoalEntity(userEntity: UserEntity, goalEntity: GoalEntity): List<GoalProofEntity>
+}

--- a/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goalproof/GoalProofService.kt
+++ b/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goalproof/GoalProofService.kt
@@ -2,15 +2,21 @@ package com.whatever.raisedragon.domain.goalproof
 
 import com.whatever.raisedragon.domain.gifticon.URL
 import com.whatever.raisedragon.domain.goal.Goal
+import com.whatever.raisedragon.domain.goal.GoalRepository
 import com.whatever.raisedragon.domain.goal.fromDto
 import com.whatever.raisedragon.domain.user.User
+import com.whatever.raisedragon.domain.user.UserRepository
 import com.whatever.raisedragon.domain.user.fromDto
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.lang.IllegalArgumentException
 
 @Service
 @Transactional
 class GoalProofService(
+    private val goalRepository: GoalRepository,
+    private val userRepository: UserRepository,
     private val goalProofRepository: GoalProofRepository
 ) {
 
@@ -29,5 +35,16 @@ class GoalProofService(
             )
         )
         return goalProof.toDto()
+    }
+
+    fun findById(goalProofId: Long): GoalProof? {
+        return goalProofRepository.findByIdOrNull(goalProofId)?.toDto()
+    }
+
+    fun findAllByGoalIdAndUserId(goalId: Long, userId: Long): List<GoalProof> {
+        val goalEntity = goalRepository.findByIdOrNull(goalId) ?: throw IllegalArgumentException()
+        val userEntity = userRepository.findByIdOrNull(userId) ?: throw IllegalArgumentException()
+        return goalProofRepository.findAllByUserEntityAndGoalEntity(goalEntity = goalEntity, userEntity = userEntity)
+            .map { it.toDto() }
     }
 }


### PR DESCRIPTION
Goal-Proof API 구현했습니다

SSOT를 보장하기 위해 GoalProof의 userEntity와 GoalEntity를 조회하는 것을 api가 아닌 domain 모듈에서 실행시켰습니다