### PR TITLE
Id컬럼을 BaseEntity에서 각 Entity로 이동합니다.

### DIFF
--- a/raisedragon-api/src/main/kotlin/com/whatever/raisedragon/controller/auth/AuthController.kt
+++ b/raisedragon-api/src/main/kotlin/com/whatever/raisedragon/controller/auth/AuthController.kt
@@ -14,7 +14,7 @@ class AuthController(
     @Operation(summary = "Login API", description = "Kakao Login")
     @PostMapping("/login")
     fun login(@RequestBody loginRequest: LoginRequest): Response<LoginResponse> {
-        return Response.success(authApplicationService.kakoLogin(loginRequest.accessToken))
+        return Response.success(authApplicationService.kakaoLogin(loginRequest.accessToken))
     }
 
     @Operation(summary = "Token Refresh API", description = "토큰 갱신")

--- a/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/BaseEntity.kt
+++ b/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/BaseEntity.kt
@@ -1,6 +1,8 @@
 package com.whatever.raisedragon.domain
 
-import jakarta.persistence.*
+import jakarta.persistence.Column
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
@@ -9,10 +11,6 @@ import java.time.LocalDateTime
 @EntityListeners(AuditingEntityListener::class)
 @MappedSuperclass
 abstract class BaseEntity {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long = 0L
 
     @Column(name = "deleted_at", nullable = true, updatable = true)
     var deletedAt: LocalDateTime? = null

--- a/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/betting/BettingEntity.kt
+++ b/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/betting/BettingEntity.kt
@@ -11,6 +11,10 @@ import org.hibernate.annotations.SQLRestriction
 @SQLRestriction("deleted_at IS NULL")
 class BettingEntity(
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     val userEntity: UserEntity,
@@ -22,7 +26,7 @@ class BettingEntity(
     @Enumerated(EnumType.STRING)
     var predictionType: PredictionType,
 
-) : BaseEntity()
+    ) : BaseEntity()
 
 enum class PredictionType {
     SUCCESS, FAIL

--- a/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/gifticon/GifticonEntity.kt
+++ b/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/gifticon/GifticonEntity.kt
@@ -10,6 +10,10 @@ import org.hibernate.annotations.SQLRestriction
 @SQLRestriction("deleted_at IS NULL")
 class GifticonEntity(
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     val userEntity: UserEntity,

--- a/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goal/GoalEntity.kt
+++ b/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goal/GoalEntity.kt
@@ -11,6 +11,10 @@ import java.time.LocalDateTime
 @SQLRestriction("deleted_at IS NULL")
 class GoalEntity(
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     val userEntity: UserEntity,

--- a/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goalcheering/GoalCheeringEntity.kt
+++ b/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goalcheering/GoalCheeringEntity.kt
@@ -11,6 +11,10 @@ import org.hibernate.annotations.SQLRestriction
 @SQLRestriction("deleted_at IS NULL")
 class GoalCheeringEntity(
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "goal_id")
     val goalEntity: GoalEntity,

--- a/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goalgifticon/GoalGifticonEntity.kt
+++ b/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goalgifticon/GoalGifticonEntity.kt
@@ -11,6 +11,10 @@ import org.hibernate.annotations.SQLRestriction
 @SQLRestriction("deleted_at IS NULL")
 class GoalGifticonEntity(
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "goal_id")
     val goalEntity: GoalEntity,

--- a/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goalproof/GoalProofEntity.kt
+++ b/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/goalproof/GoalProofEntity.kt
@@ -12,6 +12,10 @@ import org.hibernate.annotations.SQLRestriction
 @SQLRestriction("deleted_at IS NULL")
 class GoalProofEntity(
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     val userEntity: UserEntity,

--- a/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/refreshtoken/RefreshTokenEntity.kt
+++ b/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/refreshtoken/RefreshTokenEntity.kt
@@ -10,6 +10,10 @@ import org.hibernate.annotations.SQLRestriction
 @SQLRestriction("deleted_at IS NULL")
 class RefreshTokenEntity(
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     val userEntity: UserEntity,

--- a/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/user/UserEntity.kt
+++ b/raisedragon-core/src/main/kotlin/com/whatever/raisedragon/domain/user/UserEntity.kt
@@ -10,18 +10,25 @@ import java.time.LocalDateTime
 @SQLRestriction("deleted_at IS NULL")
 class UserEntity(
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
     @Column(name = "oauth_token_payload", nullable = true, length = 255)
-    val oauthTokenPayload: String?,
+    var oauthTokenPayload: String?,
 
     @Column(name = "fcm_token_payload", nullable = true, length = 255)
-    val fcmTokenPayload: String?,
+    var fcmTokenPayload: String?,
 
     @Embedded
     var nickname: Nickname
 
-) : BaseEntity()
+) : BaseEntity() {
+
+}
 
 fun User.fromDto(): UserEntity = UserEntity(
+    id = id!!,
     oauthTokenPayload = oauthTokenPayload,
     fcmTokenPayload = fcmTokenPayload,
     nickname = nickname,


### PR DESCRIPTION
기존 코드에는 fromDto()메서드를 통해 VO -> Entity로 변환하는 흐름에서, Entity의 생성자에 id 컬럼의 값을 넣지 못하는 상황이 발생했습니다.

(id라는 필드 자체가 BaseEntity에 있기 때문에) 따라서 생성자에 id값을 넣지 못해 null로 해당 값이 부여되는 현상으로 엔티티가 정상적으로 운영되지 않던 현상이 있었기 때문에 이를 해결하기 위하여 

id 컬럼을 각 엔티티에 부여하는 것으로 변경했습니다.