### PR TITLE
Fix providing jackson2 object mapper builder login

### DIFF
--- a/raisedragon-api/src/main/kotlin/com/whatever/raisedragon/config/JacksonConfig.kt
+++ b/raisedragon-api/src/main/kotlin/com/whatever/raisedragon/config/JacksonConfig.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder
@@ -16,12 +17,14 @@ import java.time.format.DateTimeFormatter
 @Configuration
 class JacksonConfig {
     @Bean
-    fun jackson2ObjectMapperBuilder(): Jackson2ObjectMapperBuilder {
-        return Jackson2ObjectMapperBuilder()
+    fun jackson2ObjectMapperBuilder(customizers: List<Jackson2ObjectMapperBuilderCustomizer>): Jackson2ObjectMapperBuilder {
+        val builder = Jackson2ObjectMapperBuilder()
             .featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
             .featuresToDisable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
             .serializerByType(LocalDateTime::class.java, LocalDateTimeSerializer(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
             .serializerByType(LocalDate::class.java, LocalDateSerializer(DateTimeFormatter.ISO_LOCAL_DATE))
             .serializerByType(LocalTime::class.java, LocalTimeSerializer(DateTimeFormatter.ISO_LOCAL_TIME))
+        customizers.forEach { customizer -> customizer.customize(builder) }
+        return builder
     }
 }


### PR DESCRIPTION
# 진행한 일
기존에 Jack2ObjectMapperBuilder를 주입하는 로직에 customziers를 추가하는 부분이 빠져있어서 Spring에서 권장하는 방식대로 ObjectMapper를 주입할 수 없어 이를 변경했습니다.

Spring에서 권장하는 방식대로 주입하면 챙길수 있는 이점은
- yml 파일을 통한 Jackson Library 설정
- Custom Module 추가로 Serializer, Deserializer 등을 추가할 수 있음
- 그 외 Spring에서 AutoConfiguration으로 제공하는 기본 Module의 동작을 기대할 수 있습니다